### PR TITLE
Feature/consulkv

### DIFF
--- a/Deploying.md
+++ b/Deploying.md
@@ -9,7 +9,7 @@ Talk to your local infrastructure team to ensure you have all of these:
 * Access to the salt master
 * Ssh access to physical machines.
 * An "/_alive" http endpoint in your application, returning "Yes".
-* A port and a backend service name in consul (if your app exposes an http endpoint) and a deployment group. This should be created using the `initdeployment` command.
+* A port and a backend service name in consul (if your app exposes an http endpoint) and a deployment group. This should be created using the `init-deployment` command.
 
 There are a lot of new things to take in so don't worry if you don't understand what everything means right now.
 
@@ -23,7 +23,7 @@ There are a lot of new things to take in so don't worry if you don't understand 
   "xpr:status": "exp-containerdeploy status -e",
   "xpr:deploy": "exp-containerdeploy deploy -e",
   "xpr:unpublished-changes": "unpublished-changes",
-  "xpr:initdeployment": "exp-containerdeploy initdeployment -e"
+  "xpr:init-deployment": "exp-containerdeploy init-deployment -e"
 }
 ```
 
@@ -31,10 +31,10 @@ There are a lot of new things to take in so don't worry if you don't understand 
 
 NOTE: For the sake of simplicity we will use the "production" environment in all examples from here on. This can of course be replaced with whatever environment your are working on.
 
-To get started, create your loadbalancing config:
+To get started, create your application context:
 
 ```
-$ npm run xpr:initdeployment production
+$ npm run xpr:init-deployment production
 # Repeat this for each environment you need to run your application in, valid envs are: production, livedata, epistage and epitest
 ```
 
@@ -85,26 +85,25 @@ If you want to see the status of your app in any given environment, you can use
 $ npm run xpr:status production
 ```
 
-To find out which port your application are running on, run:
-
-```
-$ npm run xpr:registerlb production
-┌──────────────────┬─────────────────────────────────────────────────────────────────────────────────┐
-│ Key              │ Value                                                                           │
-├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
-│ config/in/option │ httplog                                                                         │
-│                  │ capture request header Host       len 64                                        │
-├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
-│ backends         │ production.susuwatari                                                           │
-├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
-│ port             │ 1147                                                                            │
-├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
-│ acl              │ xxxxxxx-xxx-xxx-xxxx                                                            │
-└──────────────────┴─────────────────────────────────────────────────────────────────────────────────┘
-```
-
-
 This will show you on what hardware your app is running and what state it is in.
+
+To find out which port your application are running on, run init-deployment again:
+
+```
+$ npm run xpr:init-deployment production
+┌──────────┬──────────────────────────────────────┐
+│ Key      │ Value                                │
+├──────────┼──────────────────────────────────────┤
+│ backends │ production.testapp                   │
+├──────────┼──────────────────────────────────────┤
+│ port     │ 1348                                 │
+├──────────┼──────────────────────────────────────┤
+│ acl      │ e1751731-58c1-2a83-13d3-485e5a9a1387 │
+└──────────┴──────────────────────────────────────┘
+Deployment group testapp-production (small) : NOT_MODIFIED
+```
+
+The above means that your application is available on: http://production.testapp.service.consul.xpr.dex.nu:1348.
 
 #### 4. Access your app
 

--- a/Deploying.md
+++ b/Deploying.md
@@ -9,7 +9,7 @@ Talk to your local infrastructure team to ensure you have all of these:
 * Access to the salt master
 * Ssh access to physical machines.
 * An "/_alive" http endpoint in your application, returning "Yes".
-* A port and a backend service name in consul (if your app exposes an http endpoint). This may be created using the `registerlb` command.
+* A port and a backend service name in consul (if your app exposes an http endpoint) and a deployment group. This should be created using the `initdeployment` command.
 
 There are a lot of new things to take in so don't worry if you don't understand what everything means right now.
 
@@ -23,7 +23,7 @@ There are a lot of new things to take in so don't worry if you don't understand 
   "xpr:status": "exp-containerdeploy status -e",
   "xpr:deploy": "exp-containerdeploy deploy -e",
   "xpr:unpublished-changes": "unpublished-changes",
-  "xpr:registerlb": "exp-containerdeploy registerlb -e"
+  "xpr:initdeployment": "exp-containerdeploy initdeployment -e"
 }
 ```
 
@@ -34,7 +34,7 @@ NOTE: For the sake of simplicity we will use the "production" environment in all
 To get started, create your loadbalancing config:
 
 ```
-$ npm run xpr:registerlb production
+$ npm run xpr:initdeployment production
 # Repeat this for each environment you need to run your application in, valid envs are: production, livedata, epistage and epitest
 ```
 

--- a/Deploying.md
+++ b/Deploying.md
@@ -5,11 +5,11 @@
 Talk to your local infrastructure team to ensure you have all of these:
 
 * Url:s etc to any external services your app uses for the concerned environment(s).
-* A helios deployment group for each environment you want to deploy to. 
+* A helios deployment group for each environment you want to deploy to.
 * Access to the salt master
 * Ssh access to physical machines.
 * An "/_alive" http endpoint in your application, returning "Yes".
-* A port and a backend service name in consul (if your app exposes an http endpoint).
+* A port and a backend service name in consul (if your app exposes an http endpoint). This may be created using the `registerlb` command.
 
 There are a lot of new things to take in so don't worry if you don't understand what everything means right now.
 
@@ -22,8 +22,8 @@ There are a lot of new things to take in so don't worry if you don't understand 
 
   "xpr:status": "exp-containerdeploy status -e",
   "xpr:deploy": "exp-containerdeploy deploy -e",
-  "xpr:unpublished-changes": "unpublished-changes"
-  
+  "xpr:unpublished-changes": "unpublished-changes",
+  "xpr:registerlb": "exp-containerdeploy registerlb -e"
 }
 ```
 
@@ -31,7 +31,15 @@ There are a lot of new things to take in so don't worry if you don't understand 
 
 NOTE: For the sake of simplicity we will use the "production" environment in all examples from here on. This can of course be replaced with whatever environment your are working on.
 
-First, determine which changes would be deployed by running:
+To get started, create your loadbalancing config:
+
+```
+$ npm run xpr:registerlb production
+# Repeat this for each environment you need to run your application in, valid envs are: production, livedata, epistage and epitest
+```
+
+
+Then, determine which changes would be deployed by running:
 
 ```
 npm run xpr:unpublished-changes production
@@ -55,13 +63,13 @@ If all goes well, you will be met with the following sight:
 
 ```
 ┌─────────────┬────────┐
-│ Status          DONE   │
+│ Status      |   DONE │
 ├─────────────┼────────┤
-│ Parallelism    1       │
+│ Parallelism    1     │
 ├─────────────┼────────┤
-│ Duration       23.709  │
+│ Duration     23.709  │
 ├─────────────┼────────┤
-│ Timeout        120     │
+│ Timeout      120     │
 └─────────────┴────────┘
 ```
 
@@ -77,13 +85,32 @@ If you want to see the status of your app in any given environment, you can use
 $ npm run xpr:status production
 ```
 
-This will show you on what hardware your app is running and what state it is in. 
+To find out which port your application are running on, run:
+
+```
+$ npm run xpr:registerlb production
+┌──────────────────┬─────────────────────────────────────────────────────────────────────────────────┐
+│ Key              │ Value                                                                           │
+├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
+│ config/in/option │ httplog                                                                         │
+│                  │ capture request header Host       len 64                                        │
+├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
+│ backends         │ production.susuwatari                                                           │
+├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
+│ port             │ 1147                                                                            │
+├──────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
+│ acl              │ xxxxxxx-xxx-xxx-xxxx                                                            │
+└──────────────────┴─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+
+This will show you on what hardware your app is running and what state it is in.
 
 #### 4. Access your app
 
 ##### www
 
-You should now be able to access the www endpoint of your application, if you have one. The adress is on the format: 
+You should now be able to access the www endpoint of your application, if you have one. The adress is on the format:
 ```
 http://[environment].[your-app-name].service.consul.xpr.dex.nu/
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add entries to the scripts section to define your exp-containership tasks.
   "xpr:deploy": "exp-containerdeploy deploy -e",
   "prexpr:deploy": "exp-ensure-unmodified && exp-ensure-master && exp-ensure-container-tests",
   "xpr:undeploy": "exp-containerdeploy undeploy -e",
-  "xpr:initdeployment": "exp-containership initdeployment -e",
+  "xpr:init-deployment": "exp-containership init-deployment -e",
   "xpr:open": "exp-containership open",
   "xpr:test": "exp-containership test",
   "xpr:shell": "exp-containership exec web bash",

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Add entries to the scripts section to define your exp-containership tasks.
   "xpr:deploy": "exp-containerdeploy deploy -e",
   "prexpr:deploy": "exp-ensure-unmodified && exp-ensure-master && exp-ensure-container-tests",
   "xpr:undeploy": "exp-containerdeploy undeploy -e",
+  "xpr:registerlb": "exp-containership registerlb -e",
   "xpr:open": "exp-containership open",
   "xpr:test": "exp-containership test",
   "xpr:shell": "exp-containership exec web bash",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following configuration options can be set in package.json under `config.exp
 | eauth        | ldap                                       | The Salt eauth type, typically pam or ldap                   |
 | nojobmerge   | false                                      | Whether to merge or overwrite the default helios job config  |
 | environments.[env].helios_deployment_group | `[npm_package_name]-[environment]` (for example `nodefish-production`) | Helios deployment group to use per environment. |
+| size         | small                                      | Size of the deployment group, must be one of <small|medium|large|xlarge> |
 
 Example:
 
@@ -31,7 +32,8 @@ Example:
     "repo": "custom-repo.com",
     "environments": {
       "production": {
-         "helios_deployment_group": "custom-deploymentgroup"
+         "helios_deployment_group": "custom-deploymentgroup",
+         "size": "medium"
       }
     }
   }
@@ -55,7 +57,7 @@ Add entries to the scripts section to define your exp-containership tasks.
   "xpr:deploy": "exp-containerdeploy deploy -e",
   "prexpr:deploy": "exp-ensure-unmodified && exp-ensure-master && exp-ensure-container-tests",
   "xpr:undeploy": "exp-containerdeploy undeploy -e",
-  "xpr:registerlb": "exp-containership registerlb -e",
+  "xpr:initdeployment": "exp-containership initdeployment -e",
   "xpr:open": "exp-containership open",
   "xpr:test": "exp-containership test",
   "xpr:shell": "exp-containership exec web bash",

--- a/scripts/exp-containerdeploy.js
+++ b/scripts/exp-containerdeploy.js
@@ -273,7 +273,7 @@ program
   });
 
 program
-  .command('initdeployment [app]')
+  .command('init-deployment [app]')
   .description('Create consul configuration and deployment group')
   .action(function (app) {
     app = ensure_app(app);

--- a/scripts/exp-containerdeploy.js
+++ b/scripts/exp-containerdeploy.js
@@ -268,6 +268,22 @@ program
   });
 
 program
+  .command('registerlb [app]')
+  .description('Setup or show loadbalancing config')
+  .action(function (app) {
+    app = ensure_app(app);
+    tasks.push(function (state, cb) {
+      execSalt('xpr-deploy.consul_config',[app, program.environment], state.ca, state.token, function (err, result) {
+        if (err) return cb(err);
+        result = JSON.parse(result);
+        printTable(_.forEach(result, function (v, k) {
+          return [v];
+        }), ['Key','Value']);
+      });
+    });
+  });
+
+program
   .command('jobs [revision] [app]')
   .description('lists all jobs for the deployment group')
   .action(function (rev, app) {

--- a/scripts/exp-containership.sh
+++ b/scripts/exp-containership.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e
-
 kernel=$(uname -s)
 machine_name="exp-docker"
 _DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
@@ -128,8 +127,13 @@ fi
 
 if [ $push == 1 ]; then
     echo "Tagging and pushing $npm_package_name:$_REV container"
-    docker tag -f $npm_package_name:$_REV ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
-    docker push ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
+    STATUS_CODE=$(curl -sSS --output /dev/stderr --write-out "%{http_code}" https://${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/v2/$npm_package_name/manifests/$_REV 2>/dev/null)
+    if [ "${STATUS_CODE}" -ne "200" ]; then
+      docker tag -f $npm_package_name:$_REV ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
+      docker push ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
+    else
+      echo "${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV already pushed. Skipping push..."
+    fi
 fi
 
 if [ $run == 1 ]; then


### PR DESCRIPTION
@carsotho @norla This adds automagic consul k/v registration. For a new application, one may run:
`$ npm run xpr:registerlb <env>`. This will assign ports and create the necessary Consul k/v configuration. And also create a acl that may be used by the team to change the k/v configuration in their application.