### PR TITLE
Label docker volume content for SELinux

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -9,6 +9,6 @@ web:
     - NODE_ENV=development
     - DEV_APP_ENABLED=true
   volumes:
-    - ./:/exp-container/app
+    - ./:/exp-container/app:Z
     # Link node modules with host fs to avoid uneccessary rebuild after container restart
-    - ./tmp/docker_node_modules:/exp-container/app/node_modules
+    - ./tmp/docker_node_modules:/exp-container/app/node_modules:Z


### PR DESCRIPTION
By default, docker does not care about SELinux labels. With the default
labels, SELinux will deny access. This results in the following:

```
web_1 | Error: EACCES, scandir '/exp-container/app'
web_1 |     at Error (native)
web_1 |
web_1 | Error: EACCES, open 'npm-debug.log.1d4afa394fc2146d144a488e8ebaded1'
web_1 |     at Error (native)
```

Adding the Z option makes it relabel objects:
https://docs.docker.com/engine/userguide/containers/dockervolumes/#volume-labels

I would assume that this will have no effect if SELinux is not being used, but
I would need help from someone to verify this.