### PR TITLE
Update node version to 6

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM exp-docker.repo.dex.nu/nodejs:5
+FROM exp-docker.repo.dex.nu/nodejs:6
 MAINTAINER Infra team Expressen <infra@expressen.se>
 
 ENV NODE_ENV=development

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM exp-docker.repo.dex.nu/nodejs:0.12
+FROM exp-docker.repo.dex.nu/nodejs:5
 MAINTAINER Infra team Expressen <infra@expressen.se>
 
 ENV NODE_ENV=development


### PR DESCRIPTION
When starting a new project we did not want to use 0.12. Is there any reason
for us to use 0.12 as default (rather than ~~5~~ 6)?