### PR TITLE
Fix docker tag unknown shorthand flag: 'f'

### DIFF
--- a/scripts/exp-containership.sh
+++ b/scripts/exp-containership.sh
@@ -141,7 +141,7 @@ if [ $push == 1 ]; then
     echo "Tagging and pushing $npm_package_name:$_REV container"
     STATUS_CODE=$(curl -sSS --output /dev/stderr --write-out "%{http_code}" https://${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/v2/$npm_package_name/manifests/$_REV 2>/dev/null)
     if [ "${STATUS_CODE}" -ne "200" ]; then
-      docker tag -f $npm_package_name:$_REV ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
+      docker tag $npm_package_name:$_REV ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
       docker push ${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV
     else
       echo "${npm_package_config_exp_containership_repo:-exp-docker.repo.dex.nu}/$npm_package_name:$_REV already pushed. Skipping push..."


### PR DESCRIPTION
After upgrade to Docker Version 1.12.0-rc2-beta16 the command 'docker tag -f' breaks push