### PR TITLE
bugfix: prompt for credentials (if required) before running unpublish…

### DIFF
--- a/scripts/unpublished-changes.sh
+++ b/scripts/unpublished-changes.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 environment="${1:-production}"
+exp-containerdeploy login
+"$(exp-containerdeploy status -e \"${environment}\" | grep 'Job Id' | cut -f2 -d ':')"
 publishedrevision="$(exp-containerdeploy status -e \"${environment}\" | grep 'Job Id' | cut -f2 -d ':')"
 
 echo "The published revision for environment '${environment}' is ${publishedrevision}"


### PR DESCRIPTION
…ed-changes

(otherwise the command sometimes stalls while waiting for an invisible login prompt)
